### PR TITLE
Fix update-manager.service ExecStart command

### DIFF
--- a/resources/update-manager.service
+++ b/resources/update-manager.service
@@ -7,7 +7,7 @@ Requires=mosquitto.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/update-manager -configFile /etc/update-manager/config.json
+ExecStart=/usr/bin/update-manager -config-file /etc/update-manager/config.json
 Restart=always
 
 [Install]


### PR DESCRIPTION
[#27] Wrong config file flag in the update-manager service file