### PR TITLE
Remove agent domain/name duplication in the config

### DIFF
--- a/api/update_manager.go
+++ b/api/update_manager.go
@@ -26,7 +26,7 @@ type UpdateAgent interface {
 
 // UpdateManagerConfig holds configuration properties for an update manager.
 type UpdateManagerConfig struct {
-	Name           string
+	Name           string `json:"-"`
 	RebootRequired bool   `json:"rebootRequired"`
 	ReadTimeout    string `json:"readTimeout"`
 }

--- a/config/config_internal.go
+++ b/config/config_internal.go
@@ -89,7 +89,6 @@ func prepareAgentsConfig(cfg *Config, domains map[string]bool) {
 	if cfg.Agents == nil {
 		cfg.Agents = newDefaultAgentsConfig()
 	} else {
-		// fill names
 		for name, agent := range cfg.Agents {
 			agent.Name = name
 		}

--- a/config/config_internal.go
+++ b/config/config_internal.go
@@ -88,6 +88,11 @@ func LoadConfig(version string) (*Config, error) {
 func prepareAgentsConfig(cfg *Config, domains map[string]bool) {
 	if cfg.Agents == nil {
 		cfg.Agents = newDefaultAgentsConfig()
+	} else {
+		// fill names
+		for name, agent := range cfg.Agents {
+			agent.Name = name
+		}
 	}
 	if len(domains) > 0 {
 		for name := range cfg.Agents {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -94,17 +94,14 @@ func TestLoadConfigFromFile(t *testing.T) {
 
 		expectedAgentValues := map[string]*api.UpdateManagerConfig{
 			"self-update": {
-				Name:           "testSUname",
 				RebootRequired: false,
 				ReadTimeout:    "20s",
 			},
 			"containers": {
-				Name:           "testContainersName",
 				RebootRequired: true,
 				ReadTimeout:    "30s",
 			},
 			"test-domain": {
-				Name:           "testDomainName",
 				RebootRequired: true,
 				ReadTimeout:    "50s",
 			},

--- a/config/flags_test.go
+++ b/config/flags_test.go
@@ -228,17 +228,17 @@ func TestParseFlags(t *testing.T) {
 		testConfigPath := "../config/testdata/config.json"
 		expectedAgentsFromConfigFile := map[string]*api.UpdateManagerConfig{
 			"self-update": {
-				Name:           "testSUname",
+				Name:           "self-update",
 				RebootRequired: false,
 				ReadTimeout:    "20s",
 			},
 			"containers": {
-				Name:           "testContainersName",
+				Name:           "containers",
 				RebootRequired: true,
 				ReadTimeout:    "30s",
 			},
 			"test-domain": {
-				Name:           "testDomainName",
+				Name:           "test-domain",
 				RebootRequired: true,
 				ReadTimeout:    "50s",
 			},
@@ -306,24 +306,24 @@ func TestParseFlags(t *testing.T) {
 		reconfiguredRTO := "2m"
 		expectedAgentsFromConfigFile := map[string]*api.UpdateManagerConfig{
 			"self-update": {
-				Name:           "testSUname",
+				Name:           "self-update",
 				RebootRequired: false,
 				ReadTimeout:    reconfiguredRTO,
 			},
 			"containers": {
-				Name:           "testContainersName",
+				Name:           "containers",
 				RebootRequired: true,
 				ReadTimeout:    "30s",
 			},
 			"test-domain": {
-				Name:           "testDomainName",
+				Name:           "test-domain",
 				RebootRequired: true,
 				ReadTimeout:    "50s",
 			},
 		}
 
 		os.Args = []string{oldArgs[0], fmt.Sprintf("--%s=%s", configFileFlagID, testConfigPath),
-			fmt.Sprintf("--%s=%s", "testSUname-read-timeout", reconfiguredRTO)}
+			fmt.Sprintf("--%s=%s", "self-update-read-timeout", reconfiguredRTO)}
 		cfg := newDefaultConfig()
 		configFilePath := ParseConfigFilePath()
 		if configFilePath != "" {

--- a/config/testdata/config.json
+++ b/config/testdata/config.json
@@ -26,17 +26,14 @@
   "phaseTimeout": "2m",
   "agents": {
     "self-update": {
-      "name": "testSUname",
       "rebootRequired": false,
       "readTimeout": "20s"
     },
     "containers": {
-      "name": "testContainersName",
       "rebootRequired": true,
       "readTimeout": "30s"
     },
     "test-domain": {
-      "name": "testDomainName",
       "rebootRequired": true,
       "readTimeout": "50s"
     }

--- a/resources/config.json
+++ b/resources/config.json
@@ -5,7 +5,6 @@
     "domain": "device",
     "agents": {
         "containers": {
-            "name": "containers",
             "rebootRequired": false,
             "readTimeout": "30s"
         }


### PR DESCRIPTION
[#38] Remove agent domain/name duplication in the config
 - skip the name field when unmarshalling
 - fill the names from the agents keys
 - fix unit test
 - update the service configuration
 
 Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov3@bosch.io>