### PR TITLE
Update Manager shall not send commands to update agents when no actions are identified

### DIFF
--- a/updatem/orchestration/update_operation.go
+++ b/updatem/orchestration/update_operation.go
@@ -86,3 +86,10 @@ func newUpdateOperation(domainAgents map[string]api.UpdateManager, activityID st
 		desiredStateCallback: desiredStateCallback,
 	}, nil
 }
+
+func (operation *updateOperation) updateStatus(status types.StatusType) {
+	operation.statusLock.Lock()
+	defer operation.statusLock.Unlock()
+
+	operation.status = status
+}

--- a/updatem/orchestration/update_operation.go
+++ b/updatem/orchestration/update_operation.go
@@ -14,6 +14,7 @@ package orchestration
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/eclipse-kanto/update-manager/api"
 	"github.com/eclipse-kanto/update-manager/api/types"
@@ -23,6 +24,7 @@ import (
 type updateOperation struct {
 	activityID string
 
+	statusLock    sync.Mutex
 	status        types.StatusType
 	delayedStatus types.StatusType
 

--- a/updatem/orchestration/update_orchestrator.go
+++ b/updatem/orchestration/update_orchestrator.go
@@ -60,10 +60,9 @@ func (orchestrator *updateOrchestrator) Apply(ctx context.Context, domainAgents 
 			message = applyErr.Error()
 		}
 
-		var status types.StatusType
 		orchestrator.operation.statusLock.Lock()
-		status = orchestrator.operation.status
-		defer orchestrator.operation.statusLock.Unlock()
+		status := orchestrator.operation.status
+		orchestrator.operation.statusLock.Unlock()
 
 		orchestrator.notifyFeedback(status, message)
 		orchestrator.disposeUpdateOperation()

--- a/updatem/orchestration/update_orchestrator.go
+++ b/updatem/orchestration/update_orchestrator.go
@@ -59,7 +59,13 @@ func (orchestrator *updateOrchestrator) Apply(ctx context.Context, domainAgents 
 		if applyErr != nil {
 			message = applyErr.Error()
 		}
-		orchestrator.notifyFeedback(orchestrator.operation.status, message)
+
+		var status types.StatusType
+		orchestrator.operation.statusLock.Lock()
+		status = orchestrator.operation.status
+		defer orchestrator.operation.statusLock.Unlock()
+
+		orchestrator.notifyFeedback(status, message)
 		orchestrator.disposeUpdateOperation()
 	}()
 

--- a/updatem/orchestration/update_orchestrator_test.go
+++ b/updatem/orchestration/update_orchestrator_test.go
@@ -47,7 +47,8 @@ func TestUpdOrchApply(t *testing.T) {
 		ctx := context.Background()
 
 		updOrchestrator := &updateOrchestrator{
-			cfg: createTestConfig(false, false),
+			cfg:          createTestConfig(false, false),
+			phaseTimeout: 10 * time.Minute,
 		}
 		domainAgent := mocks.NewMockUpdateManager(mockCtrl)
 
@@ -60,7 +61,7 @@ func TestUpdOrchApply(t *testing.T) {
 			"domain1": domainAgent,
 		}
 
-		eventCallback.EXPECT().HandleDesiredStateFeedbackEvent("device", test.ActivityID, "", gomock.Any(), "", []*types.Action{}).Times(4)
+		eventCallback.EXPECT().HandleDesiredStateFeedbackEvent("device", test.ActivityID, "", gomock.Any(), "", []*types.Action{}).Times(3)
 
 		go applyDesiredState(ctx, updOrchestrator, doneChan, domainAgents, test.ActivityID, test.DesiredState, eventCallback)
 

--- a/updatem/orchestration/update_orchestrator_test.go
+++ b/updatem/orchestration/update_orchestrator_test.go
@@ -54,7 +54,7 @@ func TestUpdOrchApply(t *testing.T) {
 		domainAgent.EXPECT().Apply(ctx, test.ActivityID, test.DesiredState).DoAndReturn(func(ctx context.Context, activityId string, desiredState *types.DesiredState) {
 			applyChan <- true
 		})
-		domainAgent.EXPECT().Name().Times(2)
+		domainAgent.EXPECT().Name().AnyTimes()
 
 		domainAgents := map[string]api.UpdateManager{
 			"domain1": domainAgent,


### PR DESCRIPTION
 [#43] Update Manager shall not send commands to update agents when no actions are identified

Signed-off-by: Filip Fidanov [Filip.Fidanov@bosch.io](mailto:Filip.Fidanov@bosch.io)