### PR TITLE
[#58] Request device owner's approval

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -54,3 +54,29 @@ type DesiredStateClient interface {
 	SendDesiredStateCommand(string, *types.DesiredStateCommand) error
 	SendCurrentStateGet(string) error
 }
+
+// OwnerConsentAgentHandler defines functions for handling the owner consent requests
+type OwnerConsentAgentHandler interface {
+	HandleOwnerConsentGet(string, int64, *types.OwnerConsent) error
+}
+
+// OwnerConsentAgentClient defines an interface for handling for owner consent requests
+type OwnerConsentAgentClient interface {
+	BaseClient
+
+	Start(OwnerConsentAgentHandler) error
+	SendOwnerConsent(string, *types.OwnerConsent) error
+}
+
+// OwnerConsentHandler defines functions for handling the owner consent
+type OwnerConsentHandler interface {
+	HandleOwnerConsent(string, int64, *types.OwnerConsent) error
+}
+
+// OwnerConsentClient defines an interface for triggering requests for owner consent
+type OwnerConsentClient interface {
+	BaseClient
+
+	Start(OwnerConsentHandler) error
+	SendOwnerConsentGet(string, *types.DesiredState) error
+}

--- a/api/types/owner_consent.go
+++ b/api/types/owner_consent.go
@@ -10,25 +10,20 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
-package orchestration
+package types
 
-type phase string
+// ConsentStatusType defines values for status within the owner consent
+type ConsentStatusType string
 
 const (
-	phaseIdentification phase = "identification"
-	phaseDownload       phase = "download"
-	phaseUpdate         phase = "update"
-	phaseActivation     phase = "activation"
-	phaseCleanup        phase = "cleanup"
+	// StatusApproved denotes that the owner has consented.
+	StatusApproved ConsentStatusType = "APPROVED"
+	// StatusDenied denotes that the owner has not consented.
+	StatusDenied ConsentStatusType = "DENIED"
 )
 
-var orderedPhases = []phase{phaseIdentification, phaseDownload, phaseUpdate, phaseActivation, phaseCleanup}
-
-func (p phase) next() phase {
-	for i := 0; i < len(orderedPhases)-1; i++ {
-		if orderedPhases[i] == p {
-			return orderedPhases[i+1]
-		}
-	}
-	return ""
+// OwnerConsent defines the payload for Owner Consent response.
+type OwnerConsent struct {
+	Status ConsentStatusType `json:"status,omitempty"`
+	// time field for scheduling could be added here
 }

--- a/api/update_orchestrator.go
+++ b/api/update_orchestrator.go
@@ -23,4 +23,5 @@ type UpdateOrchestrator interface {
 	Apply(context.Context, map[string]UpdateManager, string, *types.DesiredState, DesiredStateFeedbackHandler) bool
 
 	DesiredStateFeedbackHandler
+	OwnerConsentHandler
 }

--- a/cmd/update-manager/main.go
+++ b/cmd/update-manager/main.go
@@ -41,17 +41,9 @@ func main() {
 	}
 	defer loggerOut.Close()
 
-	var client api.UpdateAgentClient
-	if cfg.ThingsEnabled {
-		client, err = mqtt.NewUpdateAgentThingsClient(cfg.Domain, cfg.MQTT)
-	} else {
-		client, err = mqtt.NewUpdateAgentClient(cfg.Domain, cfg.MQTT)
-	}
+	uac, um, err := initUpdateManager(cfg)
 	if err == nil {
-		updateManager, err := orchestration.NewUpdateManager(version, cfg, client, orchestration.NewUpdateOrchestrator(cfg))
-		if err == nil {
-			err = app.Launch(cfg, client, updateManager)
-		}
+		err = app.Launch(cfg, uac, um)
 	}
 
 	if err != nil {
@@ -59,4 +51,32 @@ func main() {
 		loggerOut.Close()
 		os.Exit(1)
 	}
+}
+
+func initUpdateManager(cfg *config.Config) (api.UpdateAgentClient, api.UpdateManager, error) {
+	var (
+		uac api.UpdateAgentClient
+		occ api.OwnerConsentClient
+		um  api.UpdateManager
+		err error
+	)
+
+	if cfg.ThingsEnabled {
+		uac, err = mqtt.NewUpdateAgentThingsClient(cfg.Domain, cfg.MQTT)
+	} else {
+		uac, err = mqtt.NewUpdateAgentClient(cfg.Domain, cfg.MQTT)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(cfg.OwnerConsentPhases) != 0 {
+		if occ, err = mqtt.NewOwnerConsentClient(cfg.Domain, uac); err != nil {
+			return nil, nil, err
+		}
+	}
+	if um, err = orchestration.NewUpdateManager(version, cfg, uac, orchestration.NewUpdateOrchestrator(cfg, occ)); err != nil {
+		return nil, nil, err
+	}
+	return uac, um, nil
 }

--- a/config/config_internal.go
+++ b/config/config_internal.go
@@ -12,7 +12,9 @@
 
 package config
 
-import "github.com/eclipse-kanto/update-manager/api"
+import (
+	"github.com/eclipse-kanto/update-manager/api"
+)
 
 const (
 	// default log config
@@ -42,6 +44,7 @@ type Config struct {
 	ReportFeedbackInterval string                              `json:"reportFeedbackInterval"`
 	CurrentStateDelay      string                              `json:"currentStateDelay"`
 	PhaseTimeout           string                              `json:"phaseTimeout"`
+	OwnerConsentPhases     []string                            `json:"ownerConsentPhases"`
 }
 
 func newDefaultConfig() *Config {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -136,6 +136,7 @@ func TestLoadConfigFromFile(t *testing.T) {
 			ReportFeedbackInterval: "2m",
 			CurrentStateDelay:      "1m",
 			PhaseTimeout:           "2m",
+			OwnerConsentPhases:     []string{"download"},
 		}
 		assert.True(t, reflect.DeepEqual(*cfg, expectedConfigValues))
 	})

--- a/config/flags_test.go
+++ b/config/flags_test.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/eclipse-kanto/update-manager/api"
@@ -129,6 +131,10 @@ func TestSetupFlags(t *testing.T) {
 			flag:         "phase-timeout",
 			expectedType: reflect.String.String(),
 		},
+		"test_flags_owner_consent_phases": {
+			flag:         "owner-consent-phases",
+			expectedType: reflect.String.String(),
+		},
 	}
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
@@ -227,6 +233,68 @@ func TestParseDomainsFlag(t *testing.T) {
 		actualDomains := parseDomainsFlag()
 		if len(actualDomains) != 0 {
 			t.Errorf("\"incorrect value: %v , expecting: empty \"", actualDomains)
+		}
+	})
+}
+func TestParseOwnerConsentPhasesFlag(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	testPhases := "download"
+
+	t.Run("test_parse_consent_phases_flag_1", func(t *testing.T) {
+		os.Args = []string{oldArgs[0], fmt.Sprintf("-%s=%s", ownerConsentPhasesFlagID, testPhases)}
+		actualConsentPhases := parseOwnerConsentPhasesFlag()
+		if len(actualConsentPhases) != 1 && !slices.Contains(actualConsentPhases, testPhases) {
+			t.Error("consent phase not set")
+		}
+	})
+
+	t.Run("test_parse_consent_phases_flag_2", func(t *testing.T) {
+		os.Args = []string{oldArgs[0], fmt.Sprintf("--%s=%s", ownerConsentPhasesFlagID, testPhases)}
+		actualConsentPhases := parseOwnerConsentPhasesFlag()
+		if len(actualConsentPhases) != 1 && !slices.Contains(actualConsentPhases, testPhases) {
+			t.Error("consent phase not set")
+		}
+	})
+
+	t.Run("test_parse_consent_phases_flag_3", func(t *testing.T) {
+		os.Args = []string{oldArgs[0], fmt.Sprintf("-%s", ownerConsentPhasesFlagID), testPhases}
+		actualConsentPhases := parseOwnerConsentPhasesFlag()
+		if len(actualConsentPhases) != 1 && !slices.Contains(actualConsentPhases, testPhases) {
+			t.Error("consent phase not set")
+		}
+	})
+
+	t.Run("test_parse_consent_phases_flag_4", func(t *testing.T) {
+		os.Args = []string{oldArgs[0], fmt.Sprintf("-%s", ownerConsentPhasesFlagID), testPhases}
+		actualConsentPhases := parseOwnerConsentPhasesFlag()
+		if len(actualConsentPhases) != 1 && !slices.Contains(actualConsentPhases, testPhases) {
+			t.Error("consent phase not set")
+		}
+	})
+
+	t.Run("test_parse_consent_phase_flag_err", func(t *testing.T) {
+		invalidConsentPhasesFlagID := "invalid"
+		os.Args = []string{oldArgs[0], fmt.Sprintf("--%s=%s", invalidConsentPhasesFlagID, testPhases)}
+		actualConsentPhases := parseOwnerConsentPhasesFlag()
+		if len(actualConsentPhases) != 0 {
+			t.Errorf("\"incorrect value: %v , expecting: empty \"", actualConsentPhases)
+		}
+	})
+
+	t.Run("test_parse_consent_phases_flag_err_1", func(t *testing.T) {
+		os.Args = []string{oldArgs[0], fmt.Sprintf("-%s", ownerConsentPhasesFlagID)}
+		actualConsentPhases := parseOwnerConsentPhasesFlag()
+		if len(actualConsentPhases) != 0 {
+			t.Errorf("\"incorrect value: %v , expecting: empty \"", actualConsentPhases)
+		}
+	})
+
+	t.Run("test_parse_consent_phases_flag_err_2", func(t *testing.T) {
+		os.Args = []string{oldArgs[0], fmt.Sprintf("--%s", ownerConsentPhasesFlagID)}
+		actualConsentPhases := parseOwnerConsentPhasesFlag()
+		if len(actualConsentPhases) != 0 {
+			t.Errorf("\"incorrect value: %v , expecting: empty \"", actualConsentPhases)
 		}
 	})
 }
@@ -371,5 +439,38 @@ func TestParseFlags(t *testing.T) {
 		}
 		parseFlags(cfg, testVersion)
 		assert.Equal(t, expectedAgents, cfg.Agents)
+	})
+	t.Run("test_owner_consent_phases", func(t *testing.T) {
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+
+		testConfigPath := "../config/testdata/config.json"
+		expectedPhases := []string{"download"}
+
+		os.Args = []string{oldArgs[0], fmt.Sprintf("--%s=%s", configFileFlagID, testConfigPath)}
+		cfg := newDefaultConfig()
+		configFilePath := ParseConfigFilePath()
+		if configFilePath != "" {
+			assert.NoError(t, LoadConfigFromFile(configFilePath, cfg))
+		}
+		parseFlags(cfg, testVersion)
+		assert.Equal(t, expectedPhases, cfg.OwnerConsentPhases)
+	})
+	t.Run("test_overwrite_owner_consent_phases", func(t *testing.T) {
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+
+		testConfigPath := "../config/testdata/config.json"
+		expectedPhases := []string{"update", "activation"}
+
+		os.Args = []string{oldArgs[0], fmt.Sprintf("--%s=%s", configFileFlagID, testConfigPath),
+			fmt.Sprintf("--%s=%s", ownerConsentPhasesFlagID, strings.Join(expectedPhases, ","))}
+		cfg := newDefaultConfig()
+		configFilePath := ParseConfigFilePath()
+		if configFilePath != "" {
+			assert.NoError(t, LoadConfigFromFile(configFilePath, cfg))
+		}
+		parseFlags(cfg, testVersion)
+		assert.Equal(t, expectedPhases, cfg.OwnerConsentPhases)
 	})
 }

--- a/config/testdata/config.json
+++ b/config/testdata/config.json
@@ -24,6 +24,7 @@
   "reportFeedbackInterval": "2m",
   "currentStateDelay": "1m",
   "phaseTimeout": "2m",
+  "ownerConsentPhases": ["download"],
   "agents": {
     "self-update": {
       "rebootRequired": false,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eclipse-kanto/update-manager
 
-go 1.17
+go 1.18
 
 require (
 	github.com/eclipse/ditto-clients-golang v0.0.0-20230504175246-3e6e17510ac4

--- a/mqtt/desired_state_client.go
+++ b/mqtt/desired_state_client.go
@@ -33,14 +33,9 @@ type desiredStateClient struct {
 
 // NewDesiredStateClient instantiates a new client for triggering MQTT requests.
 func NewDesiredStateClient(domain string, updateAgent api.UpdateAgentClient) (api.DesiredStateClient, error) {
-	var mqttClient *mqttClient
-	switch v := updateAgent.(type) {
-	case *updateAgentClient:
-		mqttClient = updateAgent.(*updateAgentClient).mqttClient
-	case *updateAgentThingsClient:
-		mqttClient = updateAgent.(*updateAgentThingsClient).mqttClient
-	default:
-		return nil, fmt.Errorf("Unexpected type: %T", v)
+	mqttClient, err := getMQTTClient(updateAgent)
+	if err != nil {
+		return nil, err
 	}
 	return &desiredStateClient{
 		mqttClient: newInternalClient(domain, mqttClient.mqttConfig, mqttClient.pahoClient),

--- a/mqtt/desired_state_client_test.go
+++ b/mqtt/desired_state_client_test.go
@@ -66,14 +66,14 @@ func TestNewDesiredStateClient(t *testing.T) {
 		},
 		"test_error": {
 			client: mockClient,
-			err:    fmt.Sprintf("Unexpected type: %T", mockClient),
+			err:    fmt.Sprintf("unexpected type: %T", mockClient),
 		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			client, err := NewDesiredStateClient("testDomain", test.client)
 			if test.err != "" {
-				assert.EqualError(t, err, fmt.Sprintf("Unexpected type: %T", test.client))
+				assert.EqualError(t, err, fmt.Sprintf("unexpected type: %T", test.client))
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, client)

--- a/mqtt/owner_consent_agent_client .go
+++ b/mqtt/owner_consent_agent_client .go
@@ -1,0 +1,124 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package mqtt
+
+import (
+	"fmt"
+
+	"github.com/eclipse-kanto/update-manager/api"
+	"github.com/eclipse-kanto/update-manager/api/types"
+	"github.com/eclipse-kanto/update-manager/logger"
+
+	pahomqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/pkg/errors"
+)
+
+type ownerConsentAgentClient struct {
+	*mqttClient
+	domain  string
+	handler api.OwnerConsentAgentHandler
+}
+
+// NewOwnerConsentAgentClient instantiates a new client for triggering MQTT requests.
+func NewOwnerConsentAgentClient(domain string, config *ConnectionConfig) (api.OwnerConsentAgentClient, error) {
+	client := &ownerConsentAgentClient{
+		mqttClient: newInternalClient(domain, newInternalConnectionConfig(config), nil),
+		domain:     domain,
+	}
+	pahoClient, err := newClient(client.mqttConfig, client.onConnect)
+	if err == nil {
+		client.pahoClient = pahoClient
+	}
+	return client, err
+}
+
+func (client *ownerConsentAgentClient) onConnect(_ pahomqtt.Client) {
+	if err := client.subscribe(); err != nil {
+		logger.ErrorErr(err, "[%s] error subscribing for OwnerConsentGet requests", client.Domain())
+	} else {
+		logger.Debug("[%s] subscribed for OwnerConsentGet requests", client.Domain())
+	}
+}
+
+// Start connects the client to the MQTT broker.
+func (client *ownerConsentAgentClient) Start(handler api.OwnerConsentAgentHandler) error {
+	client.handler = handler
+	token := client.pahoClient.Connect()
+	if !token.WaitTimeout(client.mqttConfig.ConnectTimeout) {
+		return fmt.Errorf("[%s] connect timed out", client.Domain())
+	}
+	return token.Error()
+}
+
+func (client *ownerConsentAgentClient) Domain() string {
+	return client.domain
+}
+
+// Stop removes the client subscription to the MQTT broker for the MQTT topics for getting owner consent.
+func (client *ownerConsentAgentClient) Stop() error {
+	if err := client.unsubscribe(); err != nil {
+		logger.WarnErr(err, "[%s] error unsubscribing for OwnerConsentGet requests", client.Domain())
+	} else {
+		logger.Debug("[%s] unsubscribed for OwnerConsentGet messages", client.Domain())
+	}
+	client.pahoClient.Disconnect(disconnectQuiesce)
+	client.handler = nil
+	return nil
+}
+
+func (client *ownerConsentAgentClient) subscribe() error {
+	logger.Debug("subscribing for '%v' topic", client.topicOwnerConsentGet)
+	token := client.pahoClient.Subscribe(client.topicOwnerConsentGet, 1, client.handleMessage)
+	if !token.WaitTimeout(client.mqttConfig.SubscribeTimeout) {
+		return fmt.Errorf("cannot subscribe for topic '%s' in '%v'", client.topicOwnerConsentGet, client.mqttConfig.SubscribeTimeout)
+	}
+	return token.Error()
+}
+
+func (client *ownerConsentAgentClient) unsubscribe() error {
+	logger.Debug("unsubscribing from '%s' topic", client.topicOwnerConsentGet)
+	token := client.pahoClient.Unsubscribe(client.topicOwnerConsentGet)
+	if !token.WaitTimeout(client.mqttConfig.UnsubscribeTimeout) {
+		return fmt.Errorf("cannot unsubscribe from topic '%s' in '%v'", client.topicOwnerConsentGet, client.mqttConfig.UnsubscribeTimeout)
+	}
+	return token.Error()
+}
+
+func (client *ownerConsentAgentClient) handleMessage(mqttClient pahomqtt.Client, message pahomqtt.Message) {
+	topic := message.Topic()
+	logger.Debug("[%s] received %s message", client.Domain(), topic)
+	if topic == client.topicOwnerConsentGet {
+		consent := &types.OwnerConsent{}
+		envelope, err := types.FromEnvelope(message.Payload(), consent)
+		if err != nil {
+			logger.ErrorErr(err, "[%s] cannot parse owner conset get message", client.Domain())
+			return
+		}
+		if err := client.handler.HandleOwnerConsentGet(envelope.ActivityID, envelope.Timestamp, consent); err != nil {
+			logger.ErrorErr(err, "[%s] error processing owner consent get message", client.Domain())
+		}
+	}
+}
+
+func (client *ownerConsentAgentClient) SendOwnerConsent(activityID string, consent *types.OwnerConsent) error {
+	logger.Debug("publishing to topic '%s'", client.topicOwnerConsent)
+	desiredStateBytes, err := types.ToEnvelope(activityID, consent)
+	if err != nil {
+		return errors.Wrapf(err, "cannot marshal owner consent message for activity-id %s", activityID)
+	}
+	token := client.pahoClient.Publish(client.topicOwnerConsent, 1, false, desiredStateBytes)
+	if !token.WaitTimeout(client.mqttConfig.AcknowledgeTimeout) {
+		return fmt.Errorf("cannot publish to topic '%s' in '%v'", client.topicOwnerConsent, client.mqttConfig.AcknowledgeTimeout)
+	}
+	return token.Error()
+}

--- a/mqtt/owner_consent_agent_client_test.go
+++ b/mqtt/owner_consent_agent_client_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package mqtt
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eclipse-kanto/update-manager/api/types"
+	mqttmocks "github.com/eclipse-kanto/update-manager/mqtt/mocks"
+	"github.com/eclipse-kanto/update-manager/test/mocks"
+
+	pahomqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOwnerConsentAgentClientStart(t *testing.T) {
+	tests := map[string]testCaseOutgoing{
+		"test_connect_ok":      {domain: "testdomain", isTimedOut: false},
+		"test_connect_timeout": {domain: "mydomain", isTimedOut: true},
+	}
+
+	mockCtrl, mockPaho, mockToken := setupCommonMocks(t)
+	defer mockCtrl.Finish()
+
+	mockHandler := mocks.NewMockOwnerConsentAgentHandler(mockCtrl)
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := &ownerConsentAgentClient{
+				domain:     test.domain,
+				mqttClient: newInternalClient(test.domain, mqttTestConfig, mockPaho),
+			}
+
+			mockPaho.EXPECT().Connect().Return(mockToken)
+			setupMockToken(mockToken, mqttTestConfig.ConnectTimeout, test.isTimedOut)
+
+			assertOutgoingResult(t, test.isTimedOut, client.Start(mockHandler))
+			assert.Equal(t, mockHandler, client.handler)
+		})
+	}
+}
+
+func TestOwnerConsentAgentClientStop(t *testing.T) {
+	tests := map[string]testCaseOutgoing{
+		//"test_disconnect_ok":      {domain: "testdomain", isTimedOut: false},
+		"test_disconnect_timeout": {domain: "mydomain", isTimedOut: true},
+	}
+
+	mockCtrl, mockPaho, mockToken := setupCommonMocks(t)
+	defer mockCtrl.Finish()
+
+	mockHandler := mocks.NewMockOwnerConsentAgentHandler(mockCtrl)
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := &ownerConsentAgentClient{
+				domain:     test.domain,
+				mqttClient: newInternalClient(test.domain, mqttTestConfig, mockPaho),
+				handler:    mockHandler,
+			}
+
+			mockPaho.EXPECT().Unsubscribe(test.domain + "update/ownerconsent/get").Return(mockToken)
+			mockPaho.EXPECT().Disconnect(disconnectQuiesce)
+			setupMockToken(mockToken, mqttTestConfig.UnsubscribeTimeout, test.isTimedOut)
+
+			assert.NoError(t, client.Stop())
+			assert.Nil(t, client.handler)
+		})
+	}
+}
+
+func TestSendOwnerConsent(t *testing.T) {
+	tests := map[string]testCaseOutgoing{
+		"test_send_owner_consent_ok":    {domain: "testdomain", isTimedOut: false},
+		"test_send_owner_consent_error": {domain: "mydomain", isTimedOut: true},
+	}
+
+	mockCtrl, mockPaho, mockToken := setupCommonMocks(t)
+	defer mockCtrl.Finish()
+
+	testConsent := &types.OwnerConsent{
+		Status: types.StatusApproved,
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := &ownerConsentAgentClient{
+				domain:     test.domain,
+				mqttClient: newInternalClient(test.domain, mqttTestConfig, mockPaho),
+			}
+			mockPaho.EXPECT().Publish(test.domain+"update/ownerconsent", uint8(1), false, gomock.Any()).DoAndReturn(
+				func(topic string, qos byte, retained bool, payload interface{}) pahomqtt.Token {
+					consent := &types.OwnerConsent{}
+					envelope, err := types.FromEnvelope(payload.([]byte), consent)
+					assert.NoError(t, err)
+					assert.Equal(t, name, envelope.ActivityID)
+					assert.True(t, envelope.Timestamp > 0)
+					assert.Equal(t, testConsent, consent)
+					return mockToken
+				})
+			setupMockToken(mockToken, mqttTestConfig.AcknowledgeTimeout, false)
+
+			assert.NoError(t, client.SendOwnerConsent(name, testConsent))
+		})
+	}
+}
+
+func TestOwnerConsentOnConnect(t *testing.T) {
+	mockCtrl, mockPaho, mockToken := setupCommonMocks(t)
+	defer mockCtrl.Finish()
+
+	client := newInternalClient("test", mqttTestConfig, mockPaho)
+
+	t.Run("test_onConnect", func(t *testing.T) {
+		mockHandler := mocks.NewMockOwnerConsentAgentHandler(mockCtrl)
+		client := &ownerConsentAgentClient{
+			mqttClient: client,
+			domain:     "test",
+			handler:    mockHandler,
+		}
+		mockPaho.EXPECT().Subscribe("testupdate/ownerconsent/get", uint8(1), gomock.Any()).Return(mockToken)
+		setupMockToken(mockToken, mqttTestConfig.SubscribeTimeout, false)
+
+		client.onConnect(nil)
+	})
+}
+
+func TestHandleOwnerConsentGetMessage(t *testing.T) {
+	tests := map[string]testCaseIncoming{
+		"test_handle_owner_conset_get_ok":         {domain: "testdomain", handlerError: nil, expectedJSONErr: false},
+		"test_handle_owner_conset_get_error":      {domain: "mydomain", handlerError: errors.New("handler error"), expectedJSONErr: false},
+		"test_handle_owner_conset_get_json_error": {domain: "testdomain", handlerError: nil, expectedJSONErr: true},
+	}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMessage := mqttmocks.NewMockMessage(mockCtrl)
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			testConsent := &types.OwnerConsent{
+				Status: types.StatusApproved,
+			}
+			testBytes, expectedCalls := testBytesToEnvelope(t, name, testConsent, test.expectedJSONErr)
+
+			mockHandler := mocks.NewMockOwnerConsentAgentHandler(mockCtrl)
+			mockHandler.EXPECT().HandleOwnerConsentGet(name, gomock.Any(), testConsent).Times(expectedCalls).Return(test.handlerError)
+
+			client := &ownerConsentAgentClient{
+				mqttClient: newInternalClient(test.domain, mqttTestConfig, nil),
+				domain:     test.domain,
+				handler:    mockHandler,
+			}
+			mockMessage.EXPECT().Topic().Return(test.domain + "update/ownerconsent/get")
+			mockMessage.EXPECT().Payload().Return(testBytes)
+
+			client.handleMessage(nil, mockMessage)
+		})
+	}
+}

--- a/mqtt/owner_consent_client _test.go
+++ b/mqtt/owner_consent_client _test.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package mqtt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/eclipse-kanto/update-manager/api"
+	"github.com/eclipse-kanto/update-manager/api/types"
+	clientsmocks "github.com/eclipse-kanto/update-manager/mqtt/mocks"
+	"github.com/eclipse-kanto/update-manager/test/mocks"
+	pahomqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewOwnerConsentClient(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockPaho := clientsmocks.NewMockClient(mockCtrl)
+	mockClient := mocks.NewMockUpdateAgentClient(mockCtrl)
+
+	tests := map[string]struct {
+		client api.UpdateAgentClient
+		err    string
+	}{
+		"test_update_agent_client": {
+			client: &updateAgentClient{
+				mqttClient: newInternalClient("testDomain", &internalConnectionConfig{}, mockPaho),
+			},
+		},
+		"test_update_agent_things_client": {
+			client: &updateAgentThingsClient{
+				updateAgentClient: &updateAgentClient{
+					mqttClient: newInternalClient("testDomain", &internalConnectionConfig{}, mockPaho),
+				},
+			},
+		},
+		"test_error": {
+			client: mockClient,
+			err:    fmt.Sprintf("unexpected type: %T", mockClient),
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client, err := NewDesiredStateClient("testDomain", test.client)
+			if test.err != "" {
+				assert.EqualError(t, err, fmt.Sprintf("unexpected type: %T", test.client))
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+			}
+		})
+	}
+}
+
+func TestOwnerConsentClientStart(t *testing.T) {
+	tests := map[string]testCaseOutgoing{
+		"test_subscribe_ok":      {domain: "testdomain", isTimedOut: false},
+		"test_subscribe_timeout": {domain: "mydomain", isTimedOut: true},
+	}
+
+	mockCtrl, mockPaho, mockToken := setupCommonMocks(t)
+	defer mockCtrl.Finish()
+
+	mockHandler := mocks.NewMockOwnerConsentHandler(mockCtrl)
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := &ownerConsentClient{
+				mqttClient: newInternalClient(test.domain, mqttTestConfig, mockPaho),
+				domain:     test.domain,
+			}
+			mockPaho.EXPECT().Subscribe(test.domain+"update/ownerconsent", uint8(1), gomock.Any()).Return(mockToken)
+			setupMockToken(mockToken, mqttTestConfig.SubscribeTimeout, test.isTimedOut)
+
+			assertOutgoingResult(t, test.isTimedOut, client.Start(mockHandler))
+			if test.isTimedOut {
+				assert.Nil(t, client.handler)
+			} else {
+				assert.Equal(t, mockHandler, client.handler)
+			}
+		})
+	}
+}
+
+func TestOwnerConsentClientStop(t *testing.T) {
+	tests := map[string]testCaseOutgoing{
+		"test_unsubscribe_ok":      {domain: "testdomain", isTimedOut: false},
+		"test_unsubscribe_timeout": {domain: "mydomain", isTimedOut: true},
+	}
+
+	mockCtrl, mockPaho, mockToken := setupCommonMocks(t)
+	defer mockCtrl.Finish()
+
+	mockHandler := mocks.NewMockOwnerConsentHandler(mockCtrl)
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := &ownerConsentClient{
+				mqttClient: newInternalClient(test.domain, mqttTestConfig, mockPaho),
+				domain:     test.domain,
+				handler:    mockHandler,
+			}
+			mockPaho.EXPECT().Unsubscribe(test.domain + "update/ownerconsent").Return(mockToken)
+			setupMockToken(mockToken, mqttTestConfig.UnsubscribeTimeout, test.isTimedOut)
+
+			assertOutgoingResult(t, test.isTimedOut, client.Stop())
+			if test.isTimedOut {
+				assert.Equal(t, mockHandler, client.handler)
+			} else {
+				assert.Nil(t, client.handler)
+			}
+		})
+	}
+}
+
+func TestSendOwnerConsentGet(t *testing.T) {
+	tests := map[string]testCaseOutgoing{
+		"test_send_owner_consent_get_ok":    {domain: "testdomain", isTimedOut: false},
+		"test_send_owner_consent_get_error": {domain: "mydomain", isTimedOut: true},
+	}
+
+	mockCtrl, mockPaho, mockToken := setupCommonMocks(t)
+	defer mockCtrl.Finish()
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			testDesiredState := &types.DesiredState{
+				Domains: []*types.Domain{
+					{ID: test.domain},
+				},
+			}
+			client, _ := NewOwnerConsentClient(test.domain, &updateAgentClient{
+				mqttClient: newInternalClient("testDomain", mqttTestConfig, mockPaho),
+			})
+			mockPaho.EXPECT().Publish(test.domain+"update/ownerconsent/get", uint8(1), false, gomock.Any()).DoAndReturn(
+				func(topic string, qos byte, retained bool, payload interface{}) pahomqtt.Token {
+					desiresState := &types.DesiredState{}
+					envelope, err := types.FromEnvelope(payload.([]byte), desiresState)
+					assert.NoError(t, err)
+					assert.Equal(t, name, envelope.ActivityID)
+					assert.True(t, envelope.Timestamp > 0)
+					assert.Equal(t, testDesiredState, desiresState)
+					return mockToken
+				})
+			setupMockToken(mockToken, mqttTestConfig.AcknowledgeTimeout, test.isTimedOut)
+
+			assertOutgoingResult(t, test.isTimedOut, client.SendOwnerConsentGet(name, testDesiredState))
+		})
+	}
+}
+
+func TestHandleOwnerConsentMessage(t *testing.T) {
+	tests := map[string]testCaseIncoming{
+		"test_handle_owner_consent_ok":         {domain: "testdomain", handlerError: nil, expectedJSONErr: false},
+		"test_handle_owner_consent_error":      {domain: "mydomain", handlerError: errors.New("handler error"), expectedJSONErr: false},
+		"test_handle_owner_consent_json_error": {domain: "testdomain", handlerError: nil, expectedJSONErr: true},
+	}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMessage := clientsmocks.NewMockMessage(mockCtrl)
+
+	testConsent := &types.OwnerConsent{
+		Status: types.StatusApproved,
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			testBytes, expectedCalls := testBytesToEnvelope(t, name, testConsent, test.expectedJSONErr)
+
+			handler := mocks.NewMockOwnerConsentHandler(mockCtrl)
+			handler.EXPECT().HandleOwnerConsent(name, gomock.Any(), testConsent).Times(expectedCalls).Return(test.handlerError)
+
+			client := &ownerConsentClient{
+				mqttClient: newInternalClient(test.domain, &internalConnectionConfig{}, nil),
+				domain:     test.domain,
+				handler:    handler,
+			}
+			mockMessage.EXPECT().Topic().Return(test.domain + "update/ownerconsent")
+			mockMessage.EXPECT().Payload().Return(testBytes)
+
+			client.handleMessage(nil, mockMessage)
+		})
+	}
+}

--- a/mqtt/owner_consent_client.go
+++ b/mqtt/owner_consent_client.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package mqtt
+
+import (
+	"fmt"
+
+	"github.com/eclipse-kanto/update-manager/api"
+	"github.com/eclipse-kanto/update-manager/api/types"
+	"github.com/eclipse-kanto/update-manager/logger"
+
+	pahomqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/pkg/errors"
+)
+
+type ownerConsentClient struct {
+	*mqttClient
+	domain  string
+	handler api.OwnerConsentHandler
+}
+
+// NewOwnerConsentClient instantiates a new client for triggering MQTT requests.
+func NewOwnerConsentClient(domain string, updateAgent api.UpdateAgentClient) (api.OwnerConsentClient, error) {
+	mqttClient, err := getMQTTClient(updateAgent)
+	if err != nil {
+		return nil, err
+	}
+	return &ownerConsentClient{
+		mqttClient: newInternalClient(domain, mqttClient.mqttConfig, mqttClient.pahoClient),
+		domain:     domain,
+	}, nil
+}
+
+func (client *ownerConsentClient) Domain() string {
+	return client.domain
+}
+
+// Start makes a client subscription to the MQTT broker for the MQTT topics for consent.
+func (client *ownerConsentClient) Start(consentHandler api.OwnerConsentHandler) error {
+	client.handler = consentHandler
+	if err := client.subscribe(); err != nil {
+		client.handler = nil
+		return fmt.Errorf("[%s] error subscribing for OwnerConsent messages: %w", client.Domain(), err)
+	}
+	logger.Debug("[%s] subscribed for OwnerConsent messages", client.Domain())
+	return nil
+}
+
+// Stop removes the client subscription to the MQTT broker for the MQTT topics for owner consent.
+func (client *ownerConsentClient) Stop() error {
+	if err := client.unsubscribe(); err != nil {
+		return fmt.Errorf("[%s] error unsubscribing for OwnerConsent messages: %w", client.Domain(), err)
+	}
+	logger.Debug("[%s] unsubscribed for OwnerConsent messages", client.Domain())
+	client.handler = nil
+	return nil
+}
+
+func (client *ownerConsentClient) subscribe() error {
+	logger.Debug("subscribing for '%v' topic", client.topicOwnerConsent)
+	token := client.pahoClient.Subscribe(client.topicOwnerConsent, 1, client.handleMessage)
+	if !token.WaitTimeout(client.mqttConfig.SubscribeTimeout) {
+		return fmt.Errorf("cannot subscribe for topic '%s' in '%v'", client.topicOwnerConsent, client.mqttConfig.SubscribeTimeout)
+	}
+	return token.Error()
+}
+
+func (client *ownerConsentClient) unsubscribe() error {
+	logger.Debug("unsubscribing from '%s' topic", client.topicOwnerConsent)
+	token := client.pahoClient.Unsubscribe(client.topicOwnerConsent)
+	if !token.WaitTimeout(client.mqttConfig.UnsubscribeTimeout) {
+		return fmt.Errorf("cannot unsubscribe from topic '%s' in '%v'", client.topicOwnerConsent, client.mqttConfig.UnsubscribeTimeout)
+	}
+	return token.Error()
+}
+
+func (client *ownerConsentClient) handleMessage(mqttClient pahomqtt.Client, message pahomqtt.Message) {
+	topic := message.Topic()
+	logger.Debug("[%s] received %s message", client.Domain(), topic)
+	if topic == client.topicOwnerConsent {
+		ownerConsent := &types.OwnerConsent{}
+		envelope, err := types.FromEnvelope(message.Payload(), ownerConsent)
+		if err != nil {
+			logger.ErrorErr(err, "[%s] cannot parse owner consent message", client.Domain())
+			return
+		}
+		if err := client.handler.HandleOwnerConsent(envelope.ActivityID, envelope.Timestamp, ownerConsent); err != nil {
+			logger.ErrorErr(err, "[%s] error processing owner consent message", client.Domain())
+		}
+	}
+}
+
+func (client *ownerConsentClient) SendOwnerConsentGet(activityID string, desiredState *types.DesiredState) error {
+	logger.Debug("publishing to topic '%s'", client.topicOwnerConsentGet)
+	desiredStateBytes, err := types.ToEnvelope(activityID, desiredState)
+	if err != nil {
+		return errors.Wrapf(err, "cannot marshal owner consent get message for activity-id %s", activityID)
+	}
+	token := client.pahoClient.Publish(client.topicOwnerConsentGet, 1, false, desiredStateBytes)
+	if !token.WaitTimeout(client.mqttConfig.AcknowledgeTimeout) {
+		return fmt.Errorf("cannot publish to topic '%s' in '%v'", client.topicOwnerConsentGet, client.mqttConfig.AcknowledgeTimeout)
+	}
+	return token.Error()
+}

--- a/mqtt/update_agent_client.go
+++ b/mqtt/update_agent_client.go
@@ -37,6 +37,8 @@ const (
 	suffixCurrentState         = "/currentstate"
 	suffixCurrentStateGet      = "/currentstate/get"
 	suffixDesiredStateFeedback = "/desiredstatefeedback"
+	suffixOwnerConsentGet      = "/ownerconsent/get"
+	suffixOwnerConsent         = "/ownerconsent"
 
 	disconnectQuiesce uint = 10000
 )
@@ -77,13 +79,15 @@ type mqttClient struct {
 	mqttConfig *internalConnectionConfig
 	pahoClient pahomqtt.Client
 
-	// incoming topics
+	// UM incoming topics
 	topicCurrentState         string
 	topicDesiredStateFeedback string
-	// outgoing topics
+	topicOwnerConsent         string
+	// UM outgoing topics
 	topicDesiredState        string
 	topicDesiredStateCommand string
 	topicCurrentStateGet     string
+	topicOwnerConsentGet     string
 }
 
 func newInternalClient(domain string, config *internalConnectionConfig, pahoClient pahomqtt.Client) *mqttClient {
@@ -97,6 +101,8 @@ func newInternalClient(domain string, config *internalConnectionConfig, pahoClie
 		topicDesiredState:         mqttPrefix + suffixDesiredState,
 		topicDesiredStateCommand:  mqttPrefix + suffixDesiredStateCommand,
 		topicDesiredStateFeedback: mqttPrefix + suffixDesiredStateFeedback,
+		topicOwnerConsent:         mqttPrefix + suffixOwnerConsent,
+		topicOwnerConsentGet:      mqttPrefix + suffixOwnerConsentGet,
 	}
 }
 

--- a/mqtt/util.go
+++ b/mqtt/util.go
@@ -10,25 +10,21 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
-package orchestration
+package mqtt
 
-type phase string
+import (
+	"fmt"
 
-const (
-	phaseIdentification phase = "identification"
-	phaseDownload       phase = "download"
-	phaseUpdate         phase = "update"
-	phaseActivation     phase = "activation"
-	phaseCleanup        phase = "cleanup"
+	"github.com/eclipse-kanto/update-manager/api"
 )
 
-var orderedPhases = []phase{phaseIdentification, phaseDownload, phaseUpdate, phaseActivation, phaseCleanup}
-
-func (p phase) next() phase {
-	for i := 0; i < len(orderedPhases)-1; i++ {
-		if orderedPhases[i] == p {
-			return orderedPhases[i+1]
-		}
+func getMQTTClient(client api.UpdateAgentClient) (*mqttClient, error) {
+	switch v := client.(type) {
+	case *updateAgentClient:
+		return client.(*updateAgentClient).mqttClient, nil
+	case *updateAgentThingsClient:
+		return client.(*updateAgentThingsClient).mqttClient, nil
+	default:
+		return nil, fmt.Errorf("unexpected type: %T", v)
 	}
-	return ""
 }

--- a/test/mocks/client_mock.go
+++ b/test/mocks/client_mock.go
@@ -390,3 +390,235 @@ func (mr *MockDesiredStateClientMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockDesiredStateClient)(nil).Stop))
 }
+
+// MockOwnerConsentAgentHandler is a mock of OwnerConsentAgentHandler interface.
+type MockOwnerConsentAgentHandler struct {
+	ctrl     *gomock.Controller
+	recorder *MockOwnerConsentAgentHandlerMockRecorder
+}
+
+// MockOwnerConsentAgentHandlerMockRecorder is the mock recorder for MockOwnerConsentAgentHandler.
+type MockOwnerConsentAgentHandlerMockRecorder struct {
+	mock *MockOwnerConsentAgentHandler
+}
+
+// NewMockOwnerConsentAgentHandler creates a new mock instance.
+func NewMockOwnerConsentAgentHandler(ctrl *gomock.Controller) *MockOwnerConsentAgentHandler {
+	mock := &MockOwnerConsentAgentHandler{ctrl: ctrl}
+	mock.recorder = &MockOwnerConsentAgentHandlerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockOwnerConsentAgentHandler) EXPECT() *MockOwnerConsentAgentHandlerMockRecorder {
+	return m.recorder
+}
+
+// HandleOwnerConsentGet mocks base method.
+func (m *MockOwnerConsentAgentHandler) HandleOwnerConsentGet(arg0 string, arg1 int64, arg2 *types.OwnerConsent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleOwnerConsentGet", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HandleOwnerConsentGet indicates an expected call of HandleOwnerConsentGet.
+func (mr *MockOwnerConsentAgentHandlerMockRecorder) HandleOwnerConsentGet(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleOwnerConsentGet", reflect.TypeOf((*MockOwnerConsentAgentHandler)(nil).HandleOwnerConsentGet), arg0, arg1, arg2)
+}
+
+// MockOwnerConsentAgentClient is a mock of OwnerConsentAgentClient interface.
+type MockOwnerConsentAgentClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockOwnerConsentAgentClientMockRecorder
+}
+
+// MockOwnerConsentAgentClientMockRecorder is the mock recorder for MockOwnerConsentAgentClient.
+type MockOwnerConsentAgentClientMockRecorder struct {
+	mock *MockOwnerConsentAgentClient
+}
+
+// NewMockOwnerConsentAgentClient creates a new mock instance.
+func NewMockOwnerConsentAgentClient(ctrl *gomock.Controller) *MockOwnerConsentAgentClient {
+	mock := &MockOwnerConsentAgentClient{ctrl: ctrl}
+	mock.recorder = &MockOwnerConsentAgentClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockOwnerConsentAgentClient) EXPECT() *MockOwnerConsentAgentClientMockRecorder {
+	return m.recorder
+}
+
+// Domain mocks base method.
+func (m *MockOwnerConsentAgentClient) Domain() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Domain")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Domain indicates an expected call of Domain.
+func (mr *MockOwnerConsentAgentClientMockRecorder) Domain() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Domain", reflect.TypeOf((*MockOwnerConsentAgentClient)(nil).Domain))
+}
+
+// SendOwnerConsent mocks base method.
+func (m *MockOwnerConsentAgentClient) SendOwnerConsent(arg0 string, arg1 *types.OwnerConsent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendOwnerConsent", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendOwnerConsent indicates an expected call of SendOwnerConsent.
+func (mr *MockOwnerConsentAgentClientMockRecorder) SendOwnerConsent(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendOwnerConsent", reflect.TypeOf((*MockOwnerConsentAgentClient)(nil).SendOwnerConsent), arg0, arg1)
+}
+
+// Start mocks base method.
+func (m *MockOwnerConsentAgentClient) Start(arg0 api.OwnerConsentAgentHandler) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Start", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Start indicates an expected call of Start.
+func (mr *MockOwnerConsentAgentClientMockRecorder) Start(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockOwnerConsentAgentClient)(nil).Start), arg0)
+}
+
+// Stop mocks base method.
+func (m *MockOwnerConsentAgentClient) Stop() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stop")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Stop indicates an expected call of Stop.
+func (mr *MockOwnerConsentAgentClientMockRecorder) Stop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockOwnerConsentAgentClient)(nil).Stop))
+}
+
+// MockOwnerConsentHandler is a mock of OwnerConsentHandler interface.
+type MockOwnerConsentHandler struct {
+	ctrl     *gomock.Controller
+	recorder *MockOwnerConsentHandlerMockRecorder
+}
+
+// MockOwnerConsentHandlerMockRecorder is the mock recorder for MockOwnerConsentHandler.
+type MockOwnerConsentHandlerMockRecorder struct {
+	mock *MockOwnerConsentHandler
+}
+
+// NewMockOwnerConsentHandler creates a new mock instance.
+func NewMockOwnerConsentHandler(ctrl *gomock.Controller) *MockOwnerConsentHandler {
+	mock := &MockOwnerConsentHandler{ctrl: ctrl}
+	mock.recorder = &MockOwnerConsentHandlerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockOwnerConsentHandler) EXPECT() *MockOwnerConsentHandlerMockRecorder {
+	return m.recorder
+}
+
+// HandleOwnerConsent mocks base method.
+func (m *MockOwnerConsentHandler) HandleOwnerConsent(arg0 string, arg1 int64, arg2 *types.OwnerConsent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleOwnerConsent", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HandleOwnerConsent indicates an expected call of HandleOwnerConsent.
+func (mr *MockOwnerConsentHandlerMockRecorder) HandleOwnerConsent(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleOwnerConsent", reflect.TypeOf((*MockOwnerConsentHandler)(nil).HandleOwnerConsent), arg0, arg1, arg2)
+}
+
+// MockOwnerConsentClient is a mock of OwnerConsentClient interface.
+type MockOwnerConsentClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockOwnerConsentClientMockRecorder
+}
+
+// MockOwnerConsentClientMockRecorder is the mock recorder for MockOwnerConsentClient.
+type MockOwnerConsentClientMockRecorder struct {
+	mock *MockOwnerConsentClient
+}
+
+// NewMockOwnerConsentClient creates a new mock instance.
+func NewMockOwnerConsentClient(ctrl *gomock.Controller) *MockOwnerConsentClient {
+	mock := &MockOwnerConsentClient{ctrl: ctrl}
+	mock.recorder = &MockOwnerConsentClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockOwnerConsentClient) EXPECT() *MockOwnerConsentClientMockRecorder {
+	return m.recorder
+}
+
+// Domain mocks base method.
+func (m *MockOwnerConsentClient) Domain() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Domain")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Domain indicates an expected call of Domain.
+func (mr *MockOwnerConsentClientMockRecorder) Domain() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Domain", reflect.TypeOf((*MockOwnerConsentClient)(nil).Domain))
+}
+
+// SendOwnerConsentGet mocks base method.
+func (m *MockOwnerConsentClient) SendOwnerConsentGet(arg0 string, arg1 *types.DesiredState) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendOwnerConsentGet", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendOwnerConsentGet indicates an expected call of SendOwnerConsentGet.
+func (mr *MockOwnerConsentClientMockRecorder) SendOwnerConsentGet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendOwnerConsentGet", reflect.TypeOf((*MockOwnerConsentClient)(nil).SendOwnerConsentGet), arg0, arg1)
+}
+
+// Start mocks base method.
+func (m *MockOwnerConsentClient) Start(arg0 api.OwnerConsentHandler) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Start", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Start indicates an expected call of Start.
+func (mr *MockOwnerConsentClientMockRecorder) Start(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockOwnerConsentClient)(nil).Start), arg0)
+}
+
+// Stop mocks base method.
+func (m *MockOwnerConsentClient) Stop() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stop")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Stop indicates an expected call of Stop.
+func (mr *MockOwnerConsentClientMockRecorder) Stop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockOwnerConsentClient)(nil).Stop))
+}

--- a/test/mocks/update_orchestrator_mock.go
+++ b/test/mocks/update_orchestrator_mock.go
@@ -73,3 +73,17 @@ func (mr *MockUpdateOrchestratorMockRecorder) HandleDesiredStateFeedbackEvent(do
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleDesiredStateFeedbackEvent", reflect.TypeOf((*MockUpdateOrchestrator)(nil).HandleDesiredStateFeedbackEvent), domain, activityID, baseline, status, message, actions)
 }
+
+// HandleOwnerConsent mocks base method.
+func (m *MockUpdateOrchestrator) HandleOwnerConsent(arg0 string, arg1 int64, arg2 *types.OwnerConsent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleOwnerConsent", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HandleOwnerConsent indicates an expected call of HandleOwnerConsent.
+func (mr *MockUpdateOrchestratorMockRecorder) HandleOwnerConsent(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleOwnerConsent", reflect.TypeOf((*MockUpdateOrchestrator)(nil).HandleOwnerConsent), arg0, arg1, arg2)
+}

--- a/updatem/orchestration/update_operation.go
+++ b/updatem/orchestration/update_operation.go
@@ -39,6 +39,8 @@ type updateOperation struct {
 	errChan chan bool
 	errMsg  string
 
+	ownerConsented chan bool
+
 	rebootRequired bool
 
 	desiredStateCallback api.DesiredStateFeedbackHandler
@@ -74,7 +76,8 @@ func newUpdateOperation(domainAgents map[string]api.UpdateManager, activityID st
 		desiredState:    desiredState,
 		phaseChannels:   generatePhaseChannels(),
 
-		errChan: make(chan bool, 1),
+		errChan:        make(chan bool, 1),
+		ownerConsented: make(chan bool),
 
 		desiredStateCallback: desiredStateCallback,
 	}, nil


### PR DESCRIPTION
- add config before which phases a owner consent will be needed
- owner consent API
- add owner consent client, used internally in UM
- add owner consent agent client, to be used by the app getting the owner approval
- modify orchestrator to wait for a owner consent
- unit test

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov3@bosch.com>